### PR TITLE
Bind to all interfaces if --bind flag isn't specified

### DIFF
--- a/httpcompressionserver.py
+++ b/httpcompressionserver.py
@@ -42,6 +42,10 @@ try:
 except ImportError:
     zlib = None
 
+
+DEFAULT_BIND = '0.0.0.0'
+
+
 # List of commonly compressed content types, copied from
 # https://github.com/h5bp/server-configs-apache.
 commonly_compressed_types = [
@@ -301,7 +305,7 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--bind', '-b', default='', metavar='ADDRESS',
+    parser.add_argument('--bind', '-b', default=DEFAULT_BIND, metavar='ADDRESS',
                         help='Specify alternate bind address '
                              '[default: all interfaces]')
     parser.add_argument('port', action='store',


### PR DESCRIPTION
This is a fix for issue #2.

Before:
```python3
$ python3 -m httpcompressionserver
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/alex/.local/lib/python3.8/site-packages/httpcompressionserver.py", line 313, in <module>
    test(HandlerClass=HTTPCompressionRequestHandler,
  File "/usr/lib/python3.8/http/server.py", line 1246, in test
    ServerClass.address_family, addr = _get_best_family(bind, port)
  File "/usr/lib/python3.8/http/server.py", line 1229, in _get_best_family
    infos = socket.getaddrinfo(
  File "/usr/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known
```

After:
```bash
$ python3 -m httpcompressionserver
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
```